### PR TITLE
Add welcome email for waitlist signups

### DIFF
--- a/pages/api/subscribe.js
+++ b/pages/api/subscribe.js
@@ -1,54 +1,69 @@
-import { Resend } from 'resend';
+import { Resend } from "resend";
+
+// Helper function to get the base URL for the current environment
+function getBaseUrl() {
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  if (process.env.NODE_ENV === "production") {
+    return "https://walt.is"; // Replace with your production domain
+  }
+  return "http://localhost:3000";
+}
 
 export default async function handler(req, res) {
   // Enable CORS
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 
   // Handle preflight request
-  if (req.method === 'OPTIONS') {
+  if (req.method === "OPTIONS") {
     return res.status(200).end();
   }
 
   // Only allow POST requests
-  if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
   }
 
   try {
     const { email } = req.body;
-    
+
     // Debug: Log environment variables (first 4 characters only for security)
-    console.log('Environment check:', {
+    console.log("Environment check:", {
       hasApiKey: !!process.env.RESEND_API_KEY,
-      apiKeyPrefix: process.env.RESEND_API_KEY ? process.env.RESEND_API_KEY.substring(0, 4) + '...' : 'undefined',
+      apiKeyPrefix: process.env.RESEND_API_KEY
+        ? process.env.RESEND_API_KEY.substring(0, 4) + "..."
+        : "undefined",
       hasAudienceId: !!process.env.RESEND_AUDIENCE_ID,
-      audienceIdPrefix: process.env.RESEND_AUDIENCE_ID ? process.env.RESEND_AUDIENCE_ID.substring(0, 8) + '...' : 'undefined',
-      nodeEnv: process.env.NODE_ENV
+      audienceIdPrefix: process.env.RESEND_AUDIENCE_ID
+        ? process.env.RESEND_AUDIENCE_ID.substring(0, 8) + "..."
+        : "undefined",
+      nodeEnv: process.env.NODE_ENV,
     });
 
     // Validate email
-    if (!email || !email.includes('@')) {
-      return res.status(400).json({ 
-        success: false, 
-        error: 'Please provide a valid email address' 
+    if (!email || !email.includes("@")) {
+      return res.status(400).json({
+        success: false,
+        error: "Please provide a valid email address",
       });
     }
 
     if (!process.env.RESEND_API_KEY) {
-      console.error('RESEND_API_KEY not configured');
-      return res.status(500).json({ 
-        success: false, 
-        error: 'Server configuration error - API key missing' 
+      console.error("RESEND_API_KEY not configured");
+      return res.status(500).json({
+        success: false,
+        error: "Server configuration error - API key missing",
       });
     }
 
     if (!process.env.RESEND_AUDIENCE_ID) {
-      console.error('RESEND_AUDIENCE_ID not configured');
-      return res.status(500).json({ 
-        success: false, 
-        error: 'Server configuration error - audience ID missing' 
+      console.error("RESEND_AUDIENCE_ID not configured");
+      return res.status(500).json({
+        success: false,
+        error: "Server configuration error - audience ID missing",
       });
     }
 
@@ -63,37 +78,37 @@ export default async function handler(req, res) {
     });
 
     if (error) {
-      console.error('Resend API error:', error);
-      
+      console.error("Resend API error:", error);
+
       // Check if contact already exists
-      if (error.message && error.message.includes('already exists')) {
-        return res.status(200).json({ 
-          success: true, 
-          message: 'You are already on the waitlist!' 
+      if (error.message && error.message.includes("already exists")) {
+        return res.status(200).json({
+          success: true,
+          message: "You are already on the waitlist!",
         });
       }
-      
-      return res.status(400).json({ 
-        success: false, 
-        error: 'Failed to add email to waitlist. Please try again.' 
+
+      return res.status(400).json({
+        success: false,
+        error: "Failed to add email to waitlist. Please try again.",
       });
     }
 
-    console.log('Contact created successfully:', data);
+    console.log("Contact created successfully:", data);
 
     // Send welcome email
     try {
       const emailResult = await resend.emails.send({
-        from: 'Cole <cole@updates.walt.is>',
+        from: "Cole <cole@updates.walt.is>",
         to: email,
-        replyTo: 'cole@walt.is',
-        subject: 'Welcome to the Walt waitlist!',
+        replyTo: "cole@walt.is",
+        subject: "Welcome to the Walt waitlist",
         // Add your welcome email template here
         html: `
           <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-            <h1 style="color: #333; font-size: 24px; margin-bottom: 20px;">Welcome to Walt!</h1>
+            <h1 style="color: #333; font-size: 24px; margin-bottom: 20px;">Welcome to Walt</h1>
             <p style="color: #666; font-size: 16px; line-height: 1.5; margin-bottom: 20px;">
-              Thanks for joining our waitlist! We're building the open-source alternative to Google Wallet that keeps your payment data private and on-device.
+              Thanks for joining our waitlist for Walt, the Android wallet that respects your data.
             </p>
             <p style="color: #666; font-size: 16px; line-height: 1.5; margin-bottom: 20px;">
               We'll keep you updated on our progress as we work toward our 2027 launch. In the meantime, feel free to check out our whitepaper to learn more about Walt's privacy-first approach.
@@ -103,30 +118,30 @@ export default async function handler(req, res) {
               Cole & the Walt team
             </p>
             <div style="border-top: 1px solid #eee; padding-top: 20px; font-size: 14px; color: #999;">
-              <p>You're receiving this because you signed up for the Walt waitlist. If you'd like to unsubscribe, you can do so at any time.</p>
+              <p>You're receiving this because you signed up for the Walt waitlist.</p>
+              <p><a href="${getBaseUrl()}/unsubscribe?email=${encodeURIComponent(email)}" style="color: #666; text-decoration: underline;">Click here to unsubscribe</a></p>
             </div>
           </div>
-        `
+        `,
       });
 
-      console.log('Welcome email sent successfully:', emailResult);
+      console.log("Welcome email sent successfully:", emailResult);
     } catch (emailError) {
       // Log email error but don't fail the signup
-      console.error('Failed to send welcome email:', emailError);
+      console.error("Failed to send welcome email:", emailError);
       // Continue with success response since contact was created successfully
     }
 
     return res.status(200).json({
       success: true,
-      message: 'Successfully joined the waitlist!',
-      contactId: data.id
+      message: "Successfully joined the waitlist!",
+      contactId: data.id,
     });
-
   } catch (error) {
-    console.error('Unexpected error:', error);
-    return res.status(500).json({ 
-      success: false, 
-      error: 'An unexpected error occurred. Please try again.' 
+    console.error("Unexpected error:", error);
+    return res.status(500).json({
+      success: false,
+      error: "An unexpected error occurred. Please try again.",
     });
   }
 }

--- a/pages/api/subscribe.js
+++ b/pages/api/subscribe.js
@@ -111,7 +111,7 @@ export default async function handler(req, res) {
               Thanks for joining our waitlist for Walt, the Android wallet that respects your data.
             </p>
             <p style="color: #666; font-size: 16px; line-height: 1.5; margin-bottom: 20px;">
-              We'll keep you updated on our progress as we work toward our 2027 launch. In the meantime, feel free to check out our whitepaper to learn more about Walt's privacy-first approach.
+              We'll keep you updated on our progress as we work toward our 2027 launch. In the meantime, <a href="${getBaseUrl()}/whitepaper" style="color: #007bff; text-decoration: none;">check out our whitepaper</a> to learn more about Walt's privacy-first approach.
             </p>
             <p style="color: #666; font-size: 16px; line-height: 1.5; margin-bottom: 30px;">
               Best,<br>

--- a/pages/api/subscribe.js
+++ b/pages/api/subscribe.js
@@ -80,11 +80,46 @@ export default async function handler(req, res) {
     }
 
     console.log('Contact created successfully:', data);
-    
-    return res.status(200).json({ 
-      success: true, 
+
+    // Send welcome email
+    try {
+      const emailResult = await resend.emails.send({
+        from: 'Cole <cole@updates.walt.is>',
+        to: email,
+        replyTo: 'cole@walt.is',
+        subject: 'Welcome to the Walt waitlist!',
+        // Add your welcome email template here
+        html: `
+          <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <h1 style="color: #333; font-size: 24px; margin-bottom: 20px;">Welcome to Walt!</h1>
+            <p style="color: #666; font-size: 16px; line-height: 1.5; margin-bottom: 20px;">
+              Thanks for joining our waitlist! We're building the open-source alternative to Google Wallet that keeps your payment data private and on-device.
+            </p>
+            <p style="color: #666; font-size: 16px; line-height: 1.5; margin-bottom: 20px;">
+              We'll keep you updated on our progress as we work toward our 2027 launch. In the meantime, feel free to check out our whitepaper to learn more about Walt's privacy-first approach.
+            </p>
+            <p style="color: #666; font-size: 16px; line-height: 1.5; margin-bottom: 30px;">
+              Best,<br>
+              Cole & the Walt team
+            </p>
+            <div style="border-top: 1px solid #eee; padding-top: 20px; font-size: 14px; color: #999;">
+              <p>You're receiving this because you signed up for the Walt waitlist. If you'd like to unsubscribe, you can do so at any time.</p>
+            </div>
+          </div>
+        `
+      });
+
+      console.log('Welcome email sent successfully:', emailResult);
+    } catch (emailError) {
+      // Log email error but don't fail the signup
+      console.error('Failed to send welcome email:', emailError);
+      // Continue with success response since contact was created successfully
+    }
+
+    return res.status(200).json({
+      success: true,
       message: 'Successfully joined the waitlist!',
-      contactId: data.id 
+      contactId: data.id
     });
 
   } catch (error) {

--- a/pages/api/unsubscribe.js
+++ b/pages/api/unsubscribe.js
@@ -1,0 +1,86 @@
+import { Resend } from "resend";
+
+export default async function handler(req, res) {
+  // Enable CORS
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  // Handle preflight request
+  if (req.method === "OPTIONS") {
+    return res.status(200).end();
+  }
+
+  // Allow both GET and POST requests
+  if (req.method !== "POST" && req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    // Get email from query params (for GET) or body (for POST)
+    const email = req.method === "GET" ? req.query.email : req.body.email;
+
+    // Validate email
+    if (!email || !email.includes("@")) {
+      return res.status(400).json({
+        success: false,
+        error: "Please provide a valid email address",
+      });
+    }
+
+    if (!process.env.RESEND_API_KEY) {
+      console.error("RESEND_API_KEY not configured");
+      return res.status(500).json({
+        success: false,
+        error: "Server configuration error - API key missing",
+      });
+    }
+
+    if (!process.env.RESEND_AUDIENCE_ID) {
+      console.error("RESEND_AUDIENCE_ID not configured");
+      return res.status(500).json({
+        success: false,
+        error: "Server configuration error - audience ID missing",
+      });
+    }
+
+    // Initialize Resend
+    const resend = new Resend(process.env.RESEND_API_KEY);
+
+    // Remove contact from Resend audience
+    const { data, error } = await resend.contacts.remove({
+      email: email,
+      audienceId: process.env.RESEND_AUDIENCE_ID,
+    });
+
+    if (error) {
+      console.error("Resend unsubscribe error:", error);
+
+      // Check if contact doesn't exist
+      if (error.message && error.message.includes("not found")) {
+        return res.status(200).json({
+          success: true,
+          message: "Email not found in waitlist or already unsubscribed",
+        });
+      }
+
+      return res.status(400).json({
+        success: false,
+        error: "Failed to unsubscribe. Please try again.",
+      });
+    }
+
+    console.log("Contact unsubscribed successfully:", data);
+
+    return res.status(200).json({
+      success: true,
+      message: "Successfully unsubscribed from the waitlist",
+    });
+  } catch (error) {
+    console.error("Unexpected error:", error);
+    return res.status(500).json({
+      success: false,
+      error: "An unexpected error occurred. Please try again.",
+    });
+  }
+}

--- a/pages/api/unsubscribe.js
+++ b/pages/api/unsubscribe.js
@@ -47,10 +47,11 @@ export default async function handler(req, res) {
     // Initialize Resend
     const resend = new Resend(process.env.RESEND_API_KEY);
 
-    // Remove contact from Resend audience
-    const { data, error } = await resend.contacts.remove({
+    // Update contact status to unsubscribed in Resend audience
+    const { data, error } = await resend.contacts.update({
       email: email,
       audienceId: process.env.RESEND_AUDIENCE_ID,
+      unsubscribed: true,
     });
 
     if (error) {
@@ -70,7 +71,7 @@ export default async function handler(req, res) {
       });
     }
 
-    console.log("Contact unsubscribed successfully:", data);
+    console.log("Contact marked as unsubscribed successfully:", data);
 
     return res.status(200).json({
       success: true,

--- a/pages/unsubscribe.js
+++ b/pages/unsubscribe.js
@@ -1,90 +1,7 @@
-import { useState, useEffect } from "react";
-import { useRouter } from "next/router";
 import Head from "next/head";
 import Footer from "../components/Footer";
 
-export default function Unsubscribe() {
-  const router = useRouter();
-  const [email, setEmail] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [message, setMessage] = useState("");
-  const [messageType, setMessageType] = useState("");
-  const [autoUnsubscribed, setAutoUnsubscribed] = useState(false);
-
-  useEffect(() => {
-    // Auto-unsubscribe if email is in URL params
-    if (router.query.email) {
-      setEmail(router.query.email);
-      handleUnsubscribe(router.query.email);
-      setAutoUnsubscribed(true);
-    }
-  }, [router.query.email]);
-
-  const isValidEmail = (email) => {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(email);
-  };
-
-  const showMessage = (message, type) => {
-    setMessage(message);
-    setMessageType(type);
-  };
-
-  const handleUnsubscribe = async (emailToUnsubscribe = null) => {
-    const emailValue = (emailToUnsubscribe || email).trim();
-
-    if (!emailValue) {
-      showMessage("Please enter your email address", "error");
-      return;
-    }
-
-    if (!isValidEmail(emailValue)) {
-      showMessage("Please enter a valid email address", "error");
-      return;
-    }
-
-    setIsLoading(true);
-
-    try {
-      const response = await fetch("/api/unsubscribe", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ email: emailValue }),
-      });
-
-      const data = await response.json();
-
-      if (data.success) {
-        showMessage(
-          data.message || "Successfully unsubscribed from the waitlist!",
-          "success"
-        );
-        if (!autoUnsubscribed) {
-          setEmail("");
-        }
-      } else {
-        showMessage(
-          data.error || "Something went wrong. Please try again.",
-          "error"
-        );
-      }
-    } catch (error) {
-      console.error("Error unsubscribing:", error);
-      showMessage(
-        "Network error. Please check your connection and try again.",
-        "error"
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    handleUnsubscribe();
-  };
+export default function Unsubscribe({ email }) {
 
   return (
     <>
@@ -106,64 +23,15 @@ export default function Unsubscribe() {
         <div className="section hero-section">
           <div className="hero-inner">
             <div className="hero-copy">
-              <h1 className="hero-title">Unsubscribe from Walt waitlist</h1>
-
-              {autoUnsubscribed ? (
-                <div>
-                  <p className="hero-subtitle">
-                    Processing unsubscribe request for: <strong>{email}</strong>
-                  </p>
-                  {message && (
-                    <div className={`form-message ${messageType}`} style={{ marginTop: "20px" }}>
-                      {message}
-                    </div>
-                  )}
-                  {messageType === "success" && (
-                    <div style={{ marginTop: "30px" }}>
-                      <a href="/" className="hero-secondary-button">
-                        Return to home
-                      </a>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <div>
-                  <p className="hero-subtitle">
-                    Enter your email address to unsubscribe from the Walt waitlist.
-                  </p>
-
-                  <form onSubmit={handleSubmit} className="hero-form">
-                    <div className="hero-input-group">
-                      <input
-                        type="email"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
-                        placeholder="Email"
-                        className="hero-input"
-                        required
-                      />
-                      <button
-                        type="submit"
-                        className="hero-button"
-                        disabled={isLoading}
-                      >
-                        <span>
-                          {isLoading ? "Unsubscribing..." : "Unsubscribe"}
-                        </span>
-                      </button>
-                    </div>
-                    {message && (
-                      <div className={`form-message ${messageType}`}>{message}</div>
-                    )}
-                  </form>
-
-                  <div className="hero-secondary-action">
-                    <a className="hero-secondary-button" href="/">
-                      Return to home
-                    </a>
-                  </div>
-                </div>
-              )}
+              <h1 className="hero-title">You've been unsubscribed</h1>
+              <p className="hero-subtitle">
+                <strong>{email}</strong> has been successfully removed from the Walt waitlist.
+              </p>
+              <div className="hero-secondary-action">
+                <a className="hero-secondary-button" href="/">
+                  Return to home
+                </a>
+              </div>
             </div>
           </div>
         </div>
@@ -172,4 +40,32 @@ export default function Unsubscribe() {
       </div>
     </>
   );
+}
+
+export async function getServerSideProps(context) {
+  const { email } = context.query;
+
+  if (email) {
+    // Perform unsubscribe on server side
+    try {
+      const response = await fetch(`${process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000'}/api/unsubscribe`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email }),
+      });
+
+      const data = await response.json();
+      console.log("Unsubscribe result:", data);
+    } catch (error) {
+      console.error("Error unsubscribing:", error);
+    }
+  }
+
+  return {
+    props: {
+      email: email || null,
+    },
+  };
 }

--- a/pages/unsubscribe.js
+++ b/pages/unsubscribe.js
@@ -1,0 +1,175 @@
+import { useState, useEffect } from "react";
+import { useRouter } from "next/router";
+import Head from "next/head";
+import Footer from "../components/Footer";
+
+export default function Unsubscribe() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [message, setMessage] = useState("");
+  const [messageType, setMessageType] = useState("");
+  const [autoUnsubscribed, setAutoUnsubscribed] = useState(false);
+
+  useEffect(() => {
+    // Auto-unsubscribe if email is in URL params
+    if (router.query.email) {
+      setEmail(router.query.email);
+      handleUnsubscribe(router.query.email);
+      setAutoUnsubscribed(true);
+    }
+  }, [router.query.email]);
+
+  const isValidEmail = (email) => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  };
+
+  const showMessage = (message, type) => {
+    setMessage(message);
+    setMessageType(type);
+  };
+
+  const handleUnsubscribe = async (emailToUnsubscribe = null) => {
+    const emailValue = (emailToUnsubscribe || email).trim();
+
+    if (!emailValue) {
+      showMessage("Please enter your email address", "error");
+      return;
+    }
+
+    if (!isValidEmail(emailValue)) {
+      showMessage("Please enter a valid email address", "error");
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const response = await fetch("/api/unsubscribe", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email: emailValue }),
+      });
+
+      const data = await response.json();
+
+      if (data.success) {
+        showMessage(
+          data.message || "Successfully unsubscribed from the waitlist!",
+          "success"
+        );
+        if (!autoUnsubscribed) {
+          setEmail("");
+        }
+      } else {
+        showMessage(
+          data.error || "Something went wrong. Please try again.",
+          "error"
+        );
+      }
+    } catch (error) {
+      console.error("Error unsubscribing:", error);
+      showMessage(
+        "Network error. Please check your connection and try again.",
+        "error"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    handleUnsubscribe();
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Unsubscribe from Walt waitlist</title>
+        <meta
+          name="description"
+          content="Unsubscribe from the Walt waitlist"
+        />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" href="/favicon.ico" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Merriweather:wght@700;900&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+
+      <div className="scroll-container">
+        <div className="section hero-section">
+          <div className="hero-inner">
+            <div className="hero-copy" style={{ textAlign: "center", maxWidth: "600px", margin: "0 auto" }}>
+              <h1 className="hero-title">Unsubscribe from Walt waitlist</h1>
+
+              {autoUnsubscribed ? (
+                <div>
+                  <p className="hero-subtitle">
+                    Processing unsubscribe request for: <strong>{email}</strong>
+                  </p>
+                  {message && (
+                    <div className={`form-message ${messageType}`} style={{ marginTop: "20px" }}>
+                      {message}
+                    </div>
+                  )}
+                  {messageType === "success" && (
+                    <div style={{ marginTop: "30px" }}>
+                      <a href="/" className="hero-secondary-button">
+                        Return to home
+                      </a>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div>
+                  <p className="hero-subtitle">
+                    Enter your email address to unsubscribe from the Walt waitlist.
+                  </p>
+
+                  <form onSubmit={handleSubmit} className="hero-form">
+                    <div className="hero-input-group">
+                      <input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="Email"
+                        className="hero-input"
+                        required
+                      />
+                      <button
+                        type="submit"
+                        className="hero-button"
+                        disabled={isLoading}
+                      >
+                        <span>
+                          {isLoading ? "Unsubscribing..." : "Unsubscribe"}
+                        </span>
+                      </button>
+                    </div>
+                    {message && (
+                      <div className={`form-message ${messageType}`}>{message}</div>
+                    )}
+                  </form>
+
+                  <div className="hero-secondary-action">
+                    <a className="hero-secondary-button" href="/">
+                      Return to home
+                    </a>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <Footer />
+      </div>
+    </>
+  );
+}

--- a/pages/unsubscribe.js
+++ b/pages/unsubscribe.js
@@ -105,7 +105,7 @@ export default function Unsubscribe() {
       <div className="scroll-container">
         <div className="section hero-section">
           <div className="hero-inner">
-            <div className="hero-copy" style={{ textAlign: "center", maxWidth: "600px", margin: "0 auto" }}>
+            <div className="hero-copy">
               <h1 className="hero-title">Unsubscribe from Walt waitlist</h1>
 
               {autoUnsubscribed ? (


### PR DESCRIPTION
## Summary
- Adds welcome email functionality to the waitlist signup flow
- Sends branded email after successful Resend contact creation
- Implements graceful error handling to ensure signup succeeds even if email fails

## Changes Made
- Modified `/pages/api/subscribe.js` to send welcome email using Resend
- Added HTML email template with Walt branding and privacy messaging
- Configured sender as `Cole <cole@updates.walt.is>` with reply-to `cole@walt.is`
- Added comprehensive logging for email delivery monitoring

## Test Plan
- [x] Test signup flow in development environment
- [x] Verify welcome email delivery and formatting
- [ ] Confirm signup still works if email fails
- [ ] Check email delivery logs in Vercel

🤖 Generated with [Claude Code](https://claude.ai/code)