### PR TITLE
Fix unsubscribe authentication issue

### DIFF
--- a/pages/unsubscribe.js
+++ b/pages/unsubscribe.js
@@ -1,8 +1,48 @@
+import { useState, useEffect } from "react";
+import { useRouter } from "next/router";
 import Head from "next/head";
 import Footer from "../components/Footer";
-import { Resend } from "resend";
 
-export default function Unsubscribe({ email, unsubscribeSuccess }) {
+export default function Unsubscribe() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [unsubscribeSuccess, setUnsubscribeSuccess] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const handleUnsubscribe = async () => {
+      const emailParam = router.query.email;
+
+      if (!emailParam) {
+        setIsLoading(false);
+        return;
+      }
+
+      setEmail(emailParam);
+
+      try {
+        const response = await fetch("/api/unsubscribe", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ email: emailParam }),
+        });
+
+        const data = await response.json();
+        setUnsubscribeSuccess(data.success);
+      } catch (error) {
+        console.error("Error unsubscribing:", error);
+        setUnsubscribeSuccess(false);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (router.isReady) {
+      handleUnsubscribe();
+    }
+  }, [router.isReady, router.query.email]);
 
   return (
     <>
@@ -24,20 +64,38 @@ export default function Unsubscribe({ email, unsubscribeSuccess }) {
         <div className="section hero-section">
           <div className="hero-inner">
             <div className="hero-copy">
-              <h1 className="hero-title">
-                {unsubscribeSuccess ? "You've been unsubscribed" : "Unsubscribe failed"}
-              </h1>
-              <p className="hero-subtitle">
-                {unsubscribeSuccess ? (
-                  <>
-                    <strong>{email}</strong> has been successfully removed from the Walt waitlist.
-                  </>
-                ) : (
-                  <>
-                    We couldn't unsubscribe <strong>{email}</strong>. Please try again or contact support.
-                  </>
-                )}
-              </p>
+              {isLoading ? (
+                <>
+                  <h1 className="hero-title">Processing unsubscribe...</h1>
+                  <p className="hero-subtitle">
+                    Please wait while we process your unsubscribe request.
+                  </p>
+                </>
+              ) : !email ? (
+                <>
+                  <h1 className="hero-title">Invalid unsubscribe link</h1>
+                  <p className="hero-subtitle">
+                    The unsubscribe link appears to be invalid. Please contact support if you need assistance.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <h1 className="hero-title">
+                    {unsubscribeSuccess ? "You've been unsubscribed" : "Unsubscribe failed"}
+                  </h1>
+                  <p className="hero-subtitle">
+                    {unsubscribeSuccess ? (
+                      <>
+                        <strong>{email}</strong> has been successfully removed from the Walt waitlist.
+                      </>
+                    ) : (
+                      <>
+                        We couldn't unsubscribe <strong>{email}</strong>. Please try again or contact support.
+                      </>
+                    )}
+                  </p>
+                </>
+              )}
               <div className="hero-secondary-action">
                 <a className="hero-secondary-button" href="/">
                   Return to home
@@ -53,52 +111,3 @@ export default function Unsubscribe({ email, unsubscribeSuccess }) {
   );
 }
 
-export async function getServerSideProps(context) {
-  const { email } = context.query;
-  let unsubscribeSuccess = false;
-
-  if (email) {
-    // Perform unsubscribe directly with Resend API
-    try {
-      if (!process.env.RESEND_API_KEY || !process.env.RESEND_AUDIENCE_ID) {
-        console.error("Missing Resend configuration");
-        return {
-          props: {
-            email: email,
-            unsubscribeSuccess: false,
-          },
-        };
-      }
-
-      const resend = new Resend(process.env.RESEND_API_KEY);
-
-      // Update contact status to unsubscribed in Resend audience
-      const { data, error } = await resend.contacts.update({
-        email: email,
-        audienceId: process.env.RESEND_AUDIENCE_ID,
-        unsubscribed: true,
-      });
-
-      if (error) {
-        console.error("Resend unsubscribe error:", error);
-
-        // Check if contact doesn't exist (treat as success since they're effectively unsubscribed)
-        if (error.message && error.message.includes("not found")) {
-          unsubscribeSuccess = true;
-        }
-      } else {
-        console.log("Contact marked as unsubscribed successfully:", data);
-        unsubscribeSuccess = true;
-      }
-    } catch (error) {
-      console.error("Error unsubscribing:", error);
-    }
-  }
-
-  return {
-    props: {
-      email: email || null,
-      unsubscribeSuccess,
-    },
-  };
-}


### PR DESCRIPTION
## Summary
- Fixes critical issue where unsubscribe links required Vercel authentication
- Users can now unsubscribe by simply clicking the email link without any authentication

## Problem Fixed
- Previous implementation used `getServerSideProps` which required server authentication
- Unsubscribe links were blocked for public users
- Users couldn't complete unsubscribe process from emails

## Solution
- Replace server-side rendering with client-side processing
- Use existing `/api/unsubscribe` endpoint via fetch
- Add loading state and proper error handling
- Maintain same UX with success/failure messaging

## Changes Made
- Remove `getServerSideProps` and Resend import from page component
- Add client-side `useEffect` to handle unsubscribe on page load
- Include loading state: "Processing unsubscribe..."
- Add error handling for invalid links and API failures

## Test Plan
- [x] Test unsubscribe page loads without authentication
- [x] Verify API call is made to `/api/unsubscribe`
- [x] Confirm Resend API is properly called
- [x] Check loading and success states work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)